### PR TITLE
add tightly coupled NotificationService without factory pattern

### DIFF
--- a/design-patterns-creational/src/main/java/org/tc/factory/EmailNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/EmailNotification.java
@@ -1,0 +1,9 @@
+package org.tc.factory;
+
+public class EmailNotification {
+
+    public void send(String message) {
+        System.out.println("Sending Email: " + message);
+        // Real-world: Call an Email API like SendGrid or SMTP
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/PushNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/PushNotification.java
@@ -1,0 +1,8 @@
+package org.tc.factory;
+
+public class PushNotification {
+    public void send(String message) {
+        System.out.println("Sending Push Notification: " + message);
+        // Real-world: Call Firebase Cloud Messaging (FCM) or APNs for iOS
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/SMSNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/SMSNotification.java
@@ -1,0 +1,9 @@
+package org.tc.factory;
+
+public class SMSNotification {
+
+    public void send(String message) {
+        System.out.println("Sending SMS: " + message);
+        // Real-world: Integrate with Twilio or another SMS API
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/without/NotificationService.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/without/NotificationService.java
@@ -1,0 +1,27 @@
+package org.tc.factory.without;
+
+import org.tc.factory.EmailNotification;
+import org.tc.factory.PushNotification;
+import org.tc.factory.SMSNotification;
+
+public class NotificationService {
+
+    public static void sendNotification(String type, String message) {
+        switch (type.toLowerCase()) {
+            case "sms":
+                SMSNotification smsNotification = new SMSNotification();
+                smsNotification.send(message);
+                break;
+            case "email":
+                EmailNotification emailNotification = new EmailNotification();
+                emailNotification.send(message);
+                break;
+            case "push":
+                PushNotification pushNotification = new PushNotification();
+                pushNotification.send(message);
+                break;
+            default:
+                throw new IllegalArgumentException("Type is unknown");
+        }
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/without/NotificationServiceTest.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/without/NotificationServiceTest.java
@@ -1,0 +1,9 @@
+package org.tc.factory.without;
+
+public class NotificationServiceTest {
+    public static void main(String[] args) {
+        NotificationService.sendNotification("push", "Test data for push system");
+
+        NotificationService.sendNotification("sms", "Test data for SMS system");
+    }
+}


### PR DESCRIPTION
- Tightly Coupled Code: If a new notification type is added (e.g., WhatsAppNotification), we have to modify NotificationService, violating Open/Closed Principle (OCP).
-  Violation of Dependency Inversion Principle: High-level modules (NotificationService) directly depend on low-level concrete classes (SMSNotification, EmailNotification, PushNotification), instead of depending on abstractions (Notification interface).
- Difficult to Unit Test: NotificationService creates objects using new, making it hard to mock dependencies in unit tests.