### PR TITLE
Refactored NotificationFactory to use Java ServiceLoader (SPI) for dynamic factory registration

### DIFF
--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/EmailNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/EmailNotification.java
@@ -1,0 +1,12 @@
+package org.tc.factory.methods.serviceloader;
+
+import org.tc.factory.simple.Notification;
+
+public class EmailNotification implements Notification {
+
+    @Override
+    public void send(String message) {
+        System.out.println("Sending Email: " + message);
+        // Real-world: Call an Email API like SendGrid or SMTP
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/EmailNotificationFactory.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/EmailNotificationFactory.java
@@ -1,0 +1,17 @@
+package org.tc.factory.methods.serviceloader;
+
+import org.tc.factory.simple.EmailNotification;
+import org.tc.factory.simple.Notification;
+
+public class EmailNotificationFactory implements NotificationFactory {
+
+    @Override
+    public Notification createNotification() {
+        return new EmailNotification();
+    }
+
+    @Override
+    public NotificationType getNotificationType() {
+        return NotificationType.EMAIL;
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/FactoryMethodDemo.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/FactoryMethodDemo.java
@@ -1,0 +1,16 @@
+package org.tc.factory.methods.serviceloader;
+
+public class FactoryMethodDemo {
+    public static void main(String[] args) {
+
+        NotificationService service = new NotificationService();
+
+        service.sendNotification(NotificationType.EMAIL, "Welcome to our platform!");
+
+
+        service.sendNotification(NotificationType.SMS, "Your OTP is 123456");
+
+
+        service.sendNotification(NotificationType.PUSH, "You have a new message!");
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/Notification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/Notification.java
@@ -1,0 +1,5 @@
+package org.tc.factory.methods.serviceloader;
+
+public interface Notification {
+    void send(String message);
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/NotificationFactory.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/NotificationFactory.java
@@ -1,0 +1,12 @@
+package org.tc.factory.methods.serviceloader;
+
+import org.tc.factory.simple.Notification;
+
+
+public interface NotificationFactory {
+
+    public Notification createNotification();
+
+    public NotificationType getNotificationType();
+}
+

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/NotificationFactoryRegistry.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/NotificationFactoryRegistry.java
@@ -1,0 +1,26 @@
+package org.tc.factory.methods.serviceloader;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+public class NotificationFactoryRegistry {
+
+    private static final Map<NotificationType, NotificationFactory> factoryMap = new HashMap<>();
+
+    static {
+        ServiceLoader<NotificationFactory> loader = ServiceLoader.load(NotificationFactory.class);
+
+        for(NotificationFactory factory : loader) {
+            factoryMap.put(factory.getNotificationType(), factory);
+        }
+    }
+
+    public static NotificationFactory getFactory(NotificationType type) {
+        if(!factoryMap.containsKey(type)) {
+            throw new IllegalArgumentException("Unknown Notification Type");
+        }
+
+        return factoryMap.get(type);
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/NotificationService.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/NotificationService.java
@@ -1,0 +1,13 @@
+package org.tc.factory.methods.serviceloader;
+
+
+import org.tc.factory.simple.Notification;
+
+public class NotificationService {
+
+    public void sendNotification(NotificationType type, String message) {
+        NotificationFactory factory = NotificationFactoryRegistry.getFactory(type);
+        Notification notification = factory.createNotification();
+        notification.send(message);
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/NotificationType.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/NotificationType.java
@@ -1,0 +1,5 @@
+package org.tc.factory.methods.serviceloader;
+
+public enum NotificationType {
+    SMS, EMAIL, PUSH;
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/PushNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/PushNotification.java
@@ -1,0 +1,12 @@
+package org.tc.factory.methods.serviceloader;
+
+import org.tc.factory.simple.Notification;
+
+public class PushNotification implements Notification {
+
+    @Override
+    public void send(String message) {
+        System.out.println("Sending Push Notification: " + message);
+        // Real-world: Call Firebase Cloud Messaging (FCM) or APNs for iOS
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/PushNotificationFactory.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/PushNotificationFactory.java
@@ -1,0 +1,17 @@
+package org.tc.factory.methods.serviceloader;
+
+import org.tc.factory.simple.Notification;
+import org.tc.factory.simple.PushNotification;
+
+public class PushNotificationFactory implements NotificationFactory {
+
+    @Override
+    public Notification createNotification() {
+        return new PushNotification();
+    }
+
+    @Override
+    public NotificationType getNotificationType() {
+        return NotificationType.PUSH;
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/SMSNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/SMSNotification.java
@@ -1,0 +1,12 @@
+package org.tc.factory.methods.serviceloader;
+
+import org.tc.factory.simple.Notification;
+
+public class SMSNotification implements Notification {
+
+    @Override
+    public void send(String message) {
+        System.out.println("Sending SMS: " + message);
+        // Real-world: Integrate with Twilio or another SMS API
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/SMSNotificationFactory.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/methods/serviceloader/SMSNotificationFactory.java
@@ -1,0 +1,17 @@
+package org.tc.factory.methods.serviceloader;
+
+import org.tc.factory.simple.Notification;
+import org.tc.factory.simple.SMSNotification;
+
+public class SMSNotificationFactory implements NotificationFactory {
+
+    @Override
+    public Notification createNotification() {
+        return new SMSNotification();
+    }
+
+    @Override
+    public NotificationType getNotificationType() {
+        return NotificationType.SMS;
+    }
+}

--- a/design-patterns-creational/src/main/resources/META-INF/services/org.tc.factory.methods.serviceloader.NotificationFactory
+++ b/design-patterns-creational/src/main/resources/META-INF/services/org.tc.factory.methods.serviceloader.NotificationFactory
@@ -1,0 +1,3 @@
+org.tc.factory.methods.serviceloader.EmailNotificationFactory
+org.tc.factory.methods.serviceloader.SMSNotificationFactory
+org.tc.factory.methods.serviceloader.PushNotificationFactory


### PR DESCRIPTION
- Made NotificationFactory a service provider interface (SPI).
- Updated concrete factories to implement `getNotificationType()` for self-registration.
- Added `META-INF/services` file for automatic service discovery.
- Modified NotificationFactoryRegistry to use `ServiceLoader` instead of manual registration.
- Removed NotificationFactoryInitializer (no longer needed).
- Improved OCP compliance—new factories can be added without modifying existing code.
- Eliminated reflection (`Class.forName()`), enhancing performance and maintainability.