### PR TITLE
Refactored NotificationFactoryProvider to Singleton with Thread Safety

### DIFF
--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/provider/NotificationFactoryProviderSingleton.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/provider/NotificationFactoryProviderSingleton.java
@@ -9,11 +9,26 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class NotificationFactoryProviderSingleton {
 
+    private static volatile NotificationFactoryProviderSingleton instance;
+
     private static final ServiceLoader<NotificationFactory> LOADER =
             ServiceLoader.load(NotificationFactory.class);
 
     private static final Map<String, NotificationFactory> FACTORY_CACHE
             = new ConcurrentHashMap<>();
+
+    private NotificationFactoryProviderSingleton(){}
+
+    public static NotificationFactoryProviderSingleton getInstance() {
+        if(instance == null) {
+            synchronized (NotificationFactoryProviderSingleton.class) {
+                if(instance == null) {
+                    instance = new NotificationFactoryProviderSingleton();
+                }
+            }
+        }
+        return instance;
+    }
 
     public static NotificationFactory getFactory(String type) {
         return FACTORY_CACHE.computeIfAbsent(type.toLowerCase(), key -> {


### PR DESCRIPTION

- Applied Double-Checked Locking to ensure a single instance of NotificationFactoryProviderSingleton.
- Used ConcurrentHashMap for thread-safe caching of NotificationFactory instances.