### PR TITLE
Refactor Notification Factory to Use Abstract Factory Pattern with Dynamic Registration

### DIFF
--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/Notification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/Notification.java
@@ -1,0 +1,5 @@
+package org.tc.factory.abstractt.dynamic;
+
+public interface Notification {
+    void send(String message);
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/NotificationFactory.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/NotificationFactory.java
@@ -1,0 +1,10 @@
+package org.tc.factory.abstractt.dynamic;
+
+public interface NotificationFactory {
+    Notification createEmailNotification();
+    Notification createSMSNotification();
+    Notification createPushNotification();
+
+    // Add a method to identify the factory type (Mobile or Web)
+    String getFactoryType();
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/NotificationFactory.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/NotificationFactory.java
@@ -1,10 +1,12 @@
 package org.tc.factory.abstractt.dynamic;
 
+import org.tc.factory.abstractt.dynamic.types.FactoryType;
+
 public interface NotificationFactory {
     Notification createEmailNotification();
     Notification createSMSNotification();
     Notification createPushNotification();
 
     // Add a method to identify the factory type (Mobile or Web)
-    String getFactoryType();
+    FactoryType getFactoryType();
 }

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/client/NotificationService.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/client/NotificationService.java
@@ -1,0 +1,30 @@
+package org.tc.factory.abstractt.dynamic.client;
+
+
+import org.tc.factory.abstractt.dynamic.Notification;
+import org.tc.factory.abstractt.dynamic.NotificationFactory;
+import org.tc.factory.abstractt.dynamic.provider.NotificationFactoryRegistry;
+
+public class NotificationService {
+    private NotificationFactory factory;
+
+    public NotificationService(String factoryType) {
+
+        this.factory = NotificationFactoryRegistry.getFactory(factoryType);
+    }
+
+    public void sendEmailNotification(String message) {
+        Notification notification = factory.createEmailNotification();
+        notification.send(message);
+    }
+
+    public void sendSMSNotification(String message) {
+        Notification notification = factory.createSMSNotification();
+        notification.send(message);
+    }
+
+    public void sendPushNotification(String message) {
+        Notification notification = factory.createPushNotification();
+        notification.send(message);
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/client/NotificationService.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/client/NotificationService.java
@@ -4,13 +4,14 @@ package org.tc.factory.abstractt.dynamic.client;
 import org.tc.factory.abstractt.dynamic.Notification;
 import org.tc.factory.abstractt.dynamic.NotificationFactory;
 import org.tc.factory.abstractt.dynamic.provider.NotificationFactoryRegistry;
+import org.tc.factory.abstractt.dynamic.types.FactoryType;
 
 public class NotificationService {
     private NotificationFactory factory;
 
-    public NotificationService(String factoryType) {
+    public NotificationService(FactoryType factoryType) {
 
-        this.factory = NotificationFactoryRegistry.getFactory(factoryType);
+        this.factory = NotificationFactoryRegistry.getInstance().getFactory(factoryType);
     }
 
     public void sendEmailNotification(String message) {

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/demo/FactoryMethodDemo.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/demo/FactoryMethodDemo.java
@@ -1,0 +1,23 @@
+package org.tc.factory.abstractt.dynamic.demo;
+
+import org.tc.factory.abstractt.dynamic.client.NotificationService;
+
+public class FactoryMethodDemo {
+    public static void main(String[] args) {
+        // Dynamically load Mobile Factory
+        NotificationService mobileService = new NotificationService("mobile");
+
+        mobileService.sendEmailNotification("Welcome to Mobile!");
+        mobileService.sendSMSNotification("Your Mobile OTP is 123456");
+        mobileService.sendPushNotification("New Mobile Alert!");
+
+        System.out.println("================================");
+
+        // Dynamically load Web Factory
+        NotificationService webService = new NotificationService("web");
+
+        webService.sendEmailNotification("Welcome to Web!");
+        webService.sendSMSNotification("Your Web OTP is 654321");
+        webService.sendPushNotification("New Web Alert!");
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/demo/FactoryMethodDemo.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/demo/FactoryMethodDemo.java
@@ -1,11 +1,12 @@
 package org.tc.factory.abstractt.dynamic.demo;
 
 import org.tc.factory.abstractt.dynamic.client.NotificationService;
+import org.tc.factory.abstractt.dynamic.types.FactoryType;
 
 public class FactoryMethodDemo {
     public static void main(String[] args) {
         // Dynamically load Mobile Factory
-        NotificationService mobileService = new NotificationService("mobile");
+        NotificationService mobileService = new NotificationService(FactoryType.MOBILE);
 
         mobileService.sendEmailNotification("Welcome to Mobile!");
         mobileService.sendSMSNotification("Your Mobile OTP is 123456");
@@ -14,7 +15,7 @@ public class FactoryMethodDemo {
         System.out.println("================================");
 
         // Dynamically load Web Factory
-        NotificationService webService = new NotificationService("web");
+        NotificationService webService = new NotificationService(FactoryType.WEB);
 
         webService.sendEmailNotification("Welcome to Web!");
         webService.sendSMSNotification("Your Web OTP is 654321");

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/impl/MobileNotificationFactory.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/impl/MobileNotificationFactory.java
@@ -1,0 +1,30 @@
+package org.tc.factory.abstractt.dynamic.impl;
+
+import org.tc.factory.abstractt.dynamic.Notification;
+import org.tc.factory.abstractt.dynamic.NotificationFactory;
+import org.tc.factory.abstractt.dynamic.mobile.MobileEmailNotification;
+import org.tc.factory.abstractt.dynamic.mobile.MobilePushNotification;
+import org.tc.factory.abstractt.dynamic.mobile.MobileSMSNotification;
+
+public class MobileNotificationFactory implements NotificationFactory {
+
+    @Override
+    public Notification createEmailNotification() {
+        return new MobileEmailNotification();
+    }
+
+    @Override
+    public Notification createSMSNotification() {
+        return new MobileSMSNotification();
+    }
+
+    @Override
+    public Notification createPushNotification() {
+        return new MobilePushNotification();
+    }
+
+    @Override
+    public String getFactoryType() {
+        return "mobile";
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/impl/MobileNotificationFactory.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/impl/MobileNotificationFactory.java
@@ -5,6 +5,7 @@ import org.tc.factory.abstractt.dynamic.NotificationFactory;
 import org.tc.factory.abstractt.dynamic.mobile.MobileEmailNotification;
 import org.tc.factory.abstractt.dynamic.mobile.MobilePushNotification;
 import org.tc.factory.abstractt.dynamic.mobile.MobileSMSNotification;
+import org.tc.factory.abstractt.dynamic.types.FactoryType;
 
 public class MobileNotificationFactory implements NotificationFactory {
 
@@ -24,7 +25,7 @@ public class MobileNotificationFactory implements NotificationFactory {
     }
 
     @Override
-    public String getFactoryType() {
-        return "mobile";
+    public FactoryType getFactoryType() {
+        return FactoryType.MOBILE;
     }
 }

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/impl/WebNotificationFactory.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/impl/WebNotificationFactory.java
@@ -1,0 +1,30 @@
+package org.tc.factory.abstractt.dynamic.impl;
+
+
+import org.tc.factory.abstractt.dynamic.Notification;
+import org.tc.factory.abstractt.dynamic.NotificationFactory;
+import org.tc.factory.abstractt.dynamic.web.WebEmailNotification;
+import org.tc.factory.abstractt.dynamic.web.WebPushNotification;
+import org.tc.factory.abstractt.dynamic.web.WebSMSNotification;
+
+public class WebNotificationFactory implements NotificationFactory {
+    @Override
+    public Notification createEmailNotification() {
+        return new WebEmailNotification();
+    }
+
+    @Override
+    public Notification createSMSNotification() {
+        return new WebSMSNotification();
+    }
+
+    @Override
+    public Notification createPushNotification() {
+        return new WebPushNotification();
+    }
+
+    @Override
+    public String getFactoryType() {
+        return "web";
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/impl/WebNotificationFactory.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/impl/WebNotificationFactory.java
@@ -3,6 +3,7 @@ package org.tc.factory.abstractt.dynamic.impl;
 
 import org.tc.factory.abstractt.dynamic.Notification;
 import org.tc.factory.abstractt.dynamic.NotificationFactory;
+import org.tc.factory.abstractt.dynamic.types.FactoryType;
 import org.tc.factory.abstractt.dynamic.web.WebEmailNotification;
 import org.tc.factory.abstractt.dynamic.web.WebPushNotification;
 import org.tc.factory.abstractt.dynamic.web.WebSMSNotification;
@@ -24,7 +25,7 @@ public class WebNotificationFactory implements NotificationFactory {
     }
 
     @Override
-    public String getFactoryType() {
-        return "web";
+    public FactoryType getFactoryType() {
+        return FactoryType.WEB;
     }
 }

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/mobile/MobileEmailNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/mobile/MobileEmailNotification.java
@@ -1,0 +1,11 @@
+package org.tc.factory.abstractt.dynamic.mobile;
+
+
+import org.tc.factory.abstractt.dynamic.Notification;
+
+public class MobileEmailNotification implements Notification {
+    @Override
+    public void send(String message) {
+        System.out.println("Sending Mobile Email Notification: " + message);
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/mobile/MobilePushNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/mobile/MobilePushNotification.java
@@ -1,0 +1,11 @@
+package org.tc.factory.abstractt.dynamic.mobile;
+
+
+import org.tc.factory.abstractt.dynamic.Notification;
+
+public class MobilePushNotification implements Notification {
+    @Override
+    public void send(String message) {
+        System.out.println("Sending Mobile Push Notification: " + message);
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/mobile/MobileSMSNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/mobile/MobileSMSNotification.java
@@ -1,0 +1,11 @@
+package org.tc.factory.abstractt.dynamic.mobile;
+
+
+import org.tc.factory.abstractt.dynamic.Notification;
+
+public class MobileSMSNotification implements Notification {
+    @Override
+    public void send(String message) {
+        System.out.println("Sending Mobile SMS Notification: " + message);
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/provider/NotificationFactoryRegistry.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/provider/NotificationFactoryRegistry.java
@@ -1,0 +1,48 @@
+package org.tc.factory.abstractt.dynamic.provider;
+
+import org.tc.factory.abstractt.dynamic.NotificationFactory;
+
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class NotificationFactoryRegistry {
+
+    private static final Map<String, NotificationFactory> factoryMap =
+            new ConcurrentHashMap<>();
+    private static volatile NotificationFactoryRegistry instance;
+
+    // Static block ensures registry is populated before any call to getFactory()
+    static {
+        getInstance();  // Triggers initialization
+    }
+
+    private NotificationFactoryRegistry() {
+        // Load factories dynamically
+        ServiceLoader<NotificationFactory> loader =
+                ServiceLoader.load(NotificationFactory.class);
+
+        for(NotificationFactory factory : loader) {
+            factoryMap.put(factory.getFactoryType(), factory);
+        }
+    }
+
+    public static NotificationFactoryRegistry getInstance() {
+        if (instance == null) {
+            synchronized (NotificationFactoryRegistry.class) {
+                if(instance == null) {
+                    instance = new NotificationFactoryRegistry();
+                }
+            }
+        }
+        return instance;
+    }
+
+    public static NotificationFactory getFactory(String factoryType) {
+        if(!factoryMap.containsKey(factoryType)) {
+            throw new IllegalArgumentException("Unknown Factory Type: " + factoryType);
+        }
+
+        return factoryMap.get(factoryType);
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/provider/NotificationFactoryRegistry.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/provider/NotificationFactoryRegistry.java
@@ -1,6 +1,7 @@
 package org.tc.factory.abstractt.dynamic.provider;
 
 import org.tc.factory.abstractt.dynamic.NotificationFactory;
+import org.tc.factory.abstractt.dynamic.types.FactoryType;
 
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -8,14 +9,10 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class NotificationFactoryRegistry {
 
-    private static final Map<String, NotificationFactory> factoryMap =
+    private static final Map<FactoryType, NotificationFactory> factoryMap =
             new ConcurrentHashMap<>();
     private static volatile NotificationFactoryRegistry instance;
 
-    // Static block ensures registry is populated before any call to getFactory()
-    static {
-        getInstance();  // Triggers initialization
-    }
 
     private NotificationFactoryRegistry() {
         // Load factories dynamically
@@ -38,8 +35,9 @@ public class NotificationFactoryRegistry {
         return instance;
     }
 
-    public static NotificationFactory getFactory(String factoryType) {
-        if(!factoryMap.containsKey(factoryType)) {
+    public static NotificationFactory getFactory(FactoryType factoryType) {
+        NotificationFactory factory = factoryMap.get(factoryType);
+        if(factory == null) {
             throw new IllegalArgumentException("Unknown Factory Type: " + factoryType);
         }
 

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/types/FactoryType.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/types/FactoryType.java
@@ -1,0 +1,5 @@
+package org.tc.factory.abstractt.dynamic.types;
+
+public enum FactoryType {
+    MOBILE, WEB;
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/web/WebEmailNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/web/WebEmailNotification.java
@@ -1,0 +1,11 @@
+package org.tc.factory.abstractt.dynamic.web;
+
+
+import org.tc.factory.abstractt.dynamic.Notification;
+
+public class WebEmailNotification implements Notification {
+    @Override
+    public void send(String message) {
+        System.out.println("Sending Web Email Notification: " + message);
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/web/WebPushNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/web/WebPushNotification.java
@@ -1,0 +1,11 @@
+package org.tc.factory.abstractt.dynamic.web;
+
+
+import org.tc.factory.abstractt.dynamic.Notification;
+
+public class WebPushNotification implements Notification {
+    @Override
+    public void send(String message) {
+        System.out.println("Sending Web Push Notification: " + message);
+    }
+}

--- a/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/web/WebSMSNotification.java
+++ b/design-patterns-creational/src/main/java/org/tc/factory/abstractt/dynamic/web/WebSMSNotification.java
@@ -1,0 +1,11 @@
+package org.tc.factory.abstractt.dynamic.web;
+
+
+import org.tc.factory.abstractt.dynamic.Notification;
+
+public class WebSMSNotification implements Notification {
+    @Override
+    public void send(String message) {
+        System.out.println("Sending Web SMS Notification: " + message);
+    }
+}

--- a/design-patterns-creational/src/main/resources/META-INF/services/org.tc.factory.abstractt.dynamic.NotificationFactory
+++ b/design-patterns-creational/src/main/resources/META-INF/services/org.tc.factory.abstractt.dynamic.NotificationFactory
@@ -1,0 +1,2 @@
+org.tc.factory.abstractt.dynamic.impl.MobileNotificationFactory
+org.tc.factory.abstractt.dynamic.impl.WebNotificationFactory


### PR DESCRIPTION

- Introduced `NotificationFactory` as an abstract factory to create email, SMS, and push notifications.
- Implemented `MobileNotificationFactory` and `WebNotificationFactory` to provide concrete notification types.
- Added `getFactoryType()` in factories to support dynamic discovery.
- Registered factories using Java SPI (`ServiceLoader`) with `META-INF/services`.
- Modified `NotificationFactoryRegistry` to auto-load factories and ensure thread safety using:
  - Singleton pattern with double-checked locking.
  - `ConcurrentHashMap` for safe concurrent access.
  - Lazy initialization for optimized performance.
- Updated `NotificationService` to interact with factories without knowing concrete implementations.
- Provided a `FactoryMethodDemo` to showcase dynamic factory selection based on `mobile` or `web`.