### PR TITLE
Implement NullLogger as a Singleton

### DIFF
--- a/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/ConsoleLogger.java
+++ b/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/ConsoleLogger.java
@@ -1,0 +1,9 @@
+package org.tc.logging.singleton;
+
+public class ConsoleLogger implements Logger {
+
+    @Override
+    public void log(String message) {
+        System.out.println("LOG: " + message);
+    }
+}

--- a/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/EnterpriseApp.java
+++ b/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/EnterpriseApp.java
@@ -1,0 +1,12 @@
+package org.tc.logging.singleton;
+
+public class EnterpriseApp {
+
+    public static void main(String[] args) {
+        Logger logger = LoggerFactory.getLogger();
+
+        logger.log("Application started");
+        logger.log("Performing business logic");
+        logger.log("Application shutting down");
+    }
+}

--- a/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/Logger.java
+++ b/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/Logger.java
@@ -1,0 +1,5 @@
+package org.tc.logging.singleton;
+
+public interface Logger {
+    void log(String message);
+}

--- a/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/LoggerFactory.java
+++ b/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/LoggerFactory.java
@@ -1,0 +1,13 @@
+package org.tc.logging.singleton;
+
+public class LoggerFactory {
+
+    public static Logger getLogger() {
+        // Read logging setting from system properties (default: false)
+        boolean isLoggingEnabled =
+                Boolean.parseBoolean(System.getProperty("logging.enabled", "false"));
+
+        return isLoggingEnabled ? new ConsoleLogger() : NullLogger.getInstance();
+
+    }
+}

--- a/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/NullLogger.java
+++ b/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/NullLogger.java
@@ -1,0 +1,24 @@
+package org.tc.logging.singleton;
+
+public class NullLogger implements Logger {
+
+    // Single instance
+    private static final NullLogger INSTANCE = new NullLogger();
+
+    // Private constructor to prevent instantiation
+    private NullLogger() {
+        if (INSTANCE != null) {
+            throw new RuntimeException("Reflection attack detected! Singleton already exists.");
+        }
+    }
+
+    // Public method to get the single instance
+    public static NullLogger getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void log(String message) {
+        // Do nothing (Null Object)
+    }
+}

--- a/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/NullLogger.java
+++ b/design-patterns-behavioral/src/main/java/org/tc/logging/singleton/NullLogger.java
@@ -2,19 +2,20 @@ package org.tc.logging.singleton;
 
 public class NullLogger implements Logger {
 
-    // Single instance
-    private static final NullLogger INSTANCE = new NullLogger();
+    private static class Holder {
+        // Single instance
+        private static final NullLogger INSTANCE = new NullLogger();
+    }
 
-    // Private constructor to prevent instantiation
     private NullLogger() {
-        if (INSTANCE != null) {
+        if (Holder.INSTANCE != null) {
             throw new RuntimeException("Reflection attack detected! Singleton already exists.");
         }
     }
 
     // Public method to get the single instance
     public static NullLogger getInstance() {
-        return INSTANCE;
+        return Holder.INSTANCE;
     }
 
     @Override


### PR DESCRIPTION
- Converted NullLogger to a singleton using eager initialization.
- Ensured thread safety with a static final instance.
- Prevented instantiation via private constructor.
- Used a getInstance() method to provide a single shared instance.

This improves performance by avoiding unnecessary object creation and ensures consistent behavior across the application.